### PR TITLE
Livebook as Braid Node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ HEALTHCHECK CMD wget --no-verbose --tries=1 --spider http://localhost:${LIVEBOOK
 
 EXPOSE 8080/tcp
 
-# ENV ELIXIR_ERL_OPTIONS="-kernel proto_dist inet6_tls -kernel ssl_dist_optfile \"/app/lib/braidnode-0.2.0/priv/ssl_dist_opts.rel\""
+ENV ERL_AFLAGS="-proto_dist proto_dist inet6_tls -ssl_dist_optfile \"/app/lib/braidnode-0.2.0/priv/ssl_dist_opts.rel\""
 ENV LIVEBOOK_COOKIE="cookie"
 
 CMD LIVEBOOK_NODE="${NODE_NAME}@${NODE_HOST}" /app/bin/server

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ HEALTHCHECK CMD wget --no-verbose --tries=1 --spider http://localhost:${LIVEBOOK
 
 EXPOSE 8080/tcp
 
-ENV ERL_AFLAGS="-proto_dist proto_dist inet6_tls -ssl_dist_optfile \"/app/lib/braidnode-0.2.0/priv/ssl_dist_opts.rel\""
+ENV ERL_AFLAGS="-proto_dist inet6_tls -ssl_dist_optfile \"/app/lib/braidnode-0.2.0/priv/ssl_dist_opts.rel\""
 ENV LIVEBOOK_COOKIE="cookie"
 
 CMD LIVEBOOK_NODE="${NODE_NAME}@${NODE_HOST}" /app/bin/server

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,4 +117,7 @@ HEALTHCHECK CMD wget --no-verbose --tries=1 --spider http://localhost:${LIVEBOOK
 
 EXPOSE 8080/tcp
 
+# ENV ELIXIR_ERL_OPTIONS="-kernel proto_dist inet6_tls -kernel ssl_dist_optfile \"/app/lib/braidnode-0.2.0/priv/ssl_dist_opts.rel\""
+ENV LIVEBOOK_COOKIE="cookie"
+
 CMD LIVEBOOK_NODE="${NODE_NAME}@${NODE_HOST}" /app/bin/server

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,30 +9,24 @@ FROM ${BASE_IMAGE} AS base-cuda
 
 ARG CUDA_VERSION
 
-RUN distro="ubuntu$(. /etc/lsb-release; echo "$DISTRIB_RELEASE" | tr -d '.')" && \
-  # Official Docker images use the sbsa packages when targetting arm64.
-  # See https://gitlab.com/nvidia/container-images/cuda/-/blob/85f465ea3343a2d7f7753a0a838701999ed58a01/dist/12.5.1/ubuntu2204/base/Dockerfile#L12
-  arch="$(if [ "$(uname -m)" = "aarch64" ]; then echo "sbsa"; else echo "x86_64"; fi)" && \
-  apt-get update && apt-get install -y ca-certificates wget && \
-  wget -qO /tmp/cuda-keyring.deb https://developer.download.nvidia.com/compute/cuda/repos/$distro/$arch/cuda-keyring_1.1-1_all.deb && \
-  dpkg -i /tmp/cuda-keyring.deb && apt-get update && \
-  # In order to minimize the image size, we install only a subset of
-  # the CUDA toolkit that is required by Elixir numerical packages
-  # (nvcc and runtime libraries). Note that we do not need to install
-  # the driver, it is already provided by NVIDIA Container Toolkit.
-  cuda_version="${CUDA_VERSION}" && cuda_major="${cuda_version%-*}" && \
-  apt-get install -y git cuda-nvcc-${CUDA_VERSION} cuda-libraries-${CUDA_VERSION} libcudnn9-cuda-$cuda_major && \
-  apt-get clean -y && rm -rf /var/lib/apt/lists/*
+RUN arch="$(if [ "$(uname -m)" = "aarch64" ]; then echo "sbsa"; else echo "x86_64"; fi)" && \
+  apk update && \
+  apk add --no-cache ca-certificates wget && \
+  wget -qO /tmp/cuda-keyring.apk https://developer.download.nvidia.com/compute/cuda/repos/alpine/$arch/cuda-keyring_${CUDA_VERSION}_all.apk && \
+  apk add --allow-untrusted /tmp/cuda-keyring.apk && \
+  apk add --no-cache git cuda-nvcc-${CUDA_VERSION} cuda-libraries-${CUDA_VERSION} libcudnn9-cuda-${CUDA_VERSION} && \
+  rm -rf /var/cache/apk/*
 
 ENV PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH"
 
 # Build stage: builds the release
 FROM base-${VARIANT} AS build
 
-RUN apt-get update && apt-get upgrade -y && \
-  apt-get install --no-install-recommends -y \
-    build-essential git && \
-  apt-get clean -y && rm -rf /var/lib/apt/lists/*
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    apk update && \
+    apk add --no-cache \
+        build-base ca-certificates git bash curl cmake && \
+    rm -rf /var/cache/apk/*
 
 WORKDIR /app
 
@@ -50,6 +44,8 @@ RUN mix local.hex --force && \
 
 # Build for production
 ENV MIX_ENV=prod
+
+COPY _checkouts/braidnode/ ./_checkouts/braidnode/
 
 # Install mix dependencies
 COPY mix.exs mix.lock ./
@@ -75,19 +71,15 @@ RUN mix do compile, release livebook
 # release with `include_erts: false`.
 FROM base-${VARIANT}
 
-ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get upgrade -y && \
-  apt-get install --no-install-recommends -y \
-    # Runtime dependencies
-    build-essential ca-certificates libncurses5-dev \
-    # In case someone uses `Mix.install/2` and point to a git repo
-    git \
-    # Additional standard tools
-    wget \
-    # In case someone uses Torchx for Nx
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+  apk update && apk upgrade && \
+  apk add --no-cache \
+    build-base ca-certificates ncurses git bash curl \
+    erlang elixir \
     cmake && \
-  apt-get clean -y && rm -rf /var/lib/apt/lists/*
+  rm -rf /var/cache/apk/*
+
 
 # Run in the /data directory by default, makes for a good place for
 # the user to mount local volume
@@ -122,4 +114,6 @@ RUN chmod -R go=u $HOME
 
 HEALTHCHECK CMD wget --no-verbose --tries=1 --spider http://localhost:${LIVEBOOK_PORT-8080}/public/health || exit 1
 
-CMD [ "/app/bin/server" ]
+EXPOSE 8080/tcp
+
+CMD LIVEBOOK_NODE="${NODE_NAME}@${NODE_HOST}" /app/bin/server

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ RUN mix local.hex --force && \
 # Build for production
 ENV MIX_ENV=prod
 
-COPY _checkouts/braidnode/ ./_checkouts/braidnode/
+# Uncomment for development
+# COPY _checkouts/braidnode/ ./_checkouts/braidnode/
 
 # Install mix dependencies
 COPY mix.exs mix.lock ./

--- a/braid-docker-build.sh
+++ b/braid-docker-build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build --build-arg BASE_IMAGE=elixir:1.18-otp-27-alpine --build-arg VARIANT=default --platform linux/amd64  -t grisp/braid_livebook .

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -17,6 +17,8 @@ config :logger, level: :warning
 config :braidnode, :braidnet_domain, ~c'localhost'
 config :braidnode, :braidnet_port, 9090
 
+config :kernel, connect_all: false
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -14,6 +14,9 @@ config :livebook, :iframe_port, 8081
 # Set log level to warning by default to reduce output
 config :logger, level: :warning
 
+config :braidnode, :braidnet_domain, ~c'localhost'
+config :braidnode, :braidnet_port, 9090
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/lib/livebook/epmd.ex
+++ b/lib/livebook/epmd.ex
@@ -36,8 +36,14 @@ defmodule Livebook.EPMD do
   def register_node(name, port, family) do
     :persistent_term.put(:livebook_dist_port, port)
 
-    case :erl_epmd.register_node(name, port, family) do
-      {:ok, creation} -> {:ok, creation}
+    case :braidnode_epmd.register_node(name, port, family) do
+      {:ok, creation} ->
+        # This modules waits for the Livebook application to run,
+        # Therefore the braidnode_epmd process is not available
+        # at the time braidnode_client connects.
+        # We need to wait Livebook to start and the register here.
+        :braidnode_connector.add_node_to_cluster()
+        {:ok, creation}
       {:error, :already_registered} -> {:error, :already_registered}
       # If registration fails because EPMD is not running, we ignore
       # that, because we do not rely on EPMD
@@ -55,7 +61,7 @@ defmodule Livebook.EPMD do
   end
 
   def port_please(name, host, timeout) do
-    :erl_epmd.port_please(name, host, timeout)
+    :braidnode_epmd.port_please(name, host, timeout)
   end
 
   # Custom callback for resolving remote runtime node domain, such as
@@ -69,12 +75,12 @@ defmodule Livebook.EPMD do
   end
 
   def address_please(name, host, address_family) do
-    :erl_epmd.address_please(name, host, address_family)
+    :braidnode_epmd.address_please(name, host, address_family)
   end
 
   # Default EPMD callbacks
 
-  defdelegate start_link(), to: :erl_epmd
-  defdelegate listen_port_please(name, host), to: :erl_epmd
-  defdelegate names(host_name), to: :erl_epmd
+  defdelegate start_link(), to: :braidnode_epmd
+  defdelegate listen_port_please(name, host), to: :braidnode_epmd
+  defdelegate names(host_name), to: :braidnode_epmd
 end

--- a/lib/livebook/epmd.ex
+++ b/lib/livebook/epmd.ex
@@ -38,10 +38,10 @@ defmodule Livebook.EPMD do
 
     case :braidnode_epmd.register_node(name, port, family) do
       {:ok, creation} ->
-        # This modules waits for the Livebook application to run,
+        # This module waits for the Livebook application to run,
         # Therefore the braidnode_epmd process is not available
         # at the time braidnode_client connects.
-        # We need to wait Livebook to start and the register here.
+        # We need to wait for Livebook to start and then register here.
         :braidnode_connector.add_node_to_cluster()
         {:ok, creation}
       {:error, :already_registered} -> {:error, :already_registered}

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,8 @@ defmodule Livebook.MixProject do
         :ssl,
         :xmerl,
         :crypto,
-        :public_key
+        :public_key,
+        :braidnode
       ],
       env: Application.get_all_env(:livebook)
     ]
@@ -129,7 +130,10 @@ defmodule Livebook.MixProject do
       {:jose, "~> 1.11.5"},
       {:req, "~> 0.5.8"},
       # Docs
-      {:ex_doc, "~> 0.30", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.30", only: :dev, runtime: false},
+      # braid deps
+      {:braidnode, git: "https://github.com/stritzinger/braidnode.git", branch: "main"}
+      # {:braidnode, path: "_checkouts/braidnode"}
     ]
   end
 


### PR DESCRIPTION
- Use alpine linux to run Livebook to minimize the docker image footprint
- Depend on braidnode
- Hack the epmd.ex module to call our own braidnode_epmd